### PR TITLE
fixed logic bug in runner and created corresponding unit test

### DIFF
--- a/local/runner/runner.go
+++ b/local/runner/runner.go
@@ -86,6 +86,7 @@ func Run(opts Opts) ([]Result, int) {
 }
 
 func simUser(opts Opts, wg *sync.WaitGroup, failsCh chan<- int, resultsCh chan<- Result) {
+
 	defer wg.Done()
 	startTime := time.Now()
 
@@ -100,7 +101,7 @@ func simUser(opts Opts, wg *sync.WaitGroup, failsCh chan<- int, resultsCh chan<-
 		response, err := makeRequest(opts.Path, opts.Timeout)
 		responseCode := response.code
 		responseBody := response.body
-		if err != nil || !slices.Contains(opts.SuccessCodes, responseCode) || responseCode != http.StatusOK {
+		if err != nil || (!slices.Contains(opts.SuccessCodes, responseCode) && responseCode != http.StatusOK) {
 
 			failsCh <- 1
 

--- a/local/runner/runner_test.go
+++ b/local/runner/runner_test.go
@@ -160,3 +160,41 @@ func TestResponseBody(t *testing.T) {
     }
   }
 }
+
+func TestAcceptNonStandardCode(t *testing.T) {
+  
+	route := "/test5"
+	rate := 1.1
+
+	serverOpts := server.TestOpts{
+		Message: "you're a failure",
+		Fail:    true,
+		Delay:   1 * time.Second,
+		Port:    8089,
+		Route:    route,
+	}
+
+	testOpts := Opts{
+		Path:         "http://localhost:8089" + route,
+		Time:         10,
+		Users:        10,
+		Timeout:      10,
+		SuccessCodes: []int{500},
+		Rate:         &rate,
+	}
+
+	err := server.TestServer(serverOpts)
+	if err != nil {
+		t.Errorf("Error starting server: %s", err)
+	}
+
+	results, _ := Run(testOpts)
+
+	if CountFailures(results) != 0 {
+		t.Errorf("Expected 0 fails, got %d", CountFailures(results))
+	}
+
+	if len(results) != 100 {
+		t.Errorf("Expected 100 results, got %d", len(results))
+	}
+}


### PR DESCRIPTION
#### Motivation
there was a bug in the runner logic related to non-standard server codes

#### Implementation
I changed a condition in the runner code to allow for nonstandard error codes.

#### Testing
I added the following unit test to the runner test suite:
```go
func TestAcceptNonStandardCode(t *testing.T) {
  
	route := "/test5"
	rate := 1.1

	serverOpts := server.TestOpts{
		Message: "you're a failure",
		Fail:    true,
		Delay:   1 * time.Second,
		Port:    8089,
		Route:    route,
	}

	testOpts := Opts{
		Path:         "http://localhost:8089" + route,
		Time:         10,
		Users:        10,
		Timeout:      10,
		SuccessCodes: []int{500},
		Rate:         &rate,
	}

	err := server.TestServer(serverOpts)
	if err != nil {
		t.Errorf("Error starting server: %s", err)
	}

	results, _ := Run(testOpts)

	if CountFailures(results) != 0 {
		t.Errorf("Expected 0 fails, got %d", CountFailures(results))
	}

	if len(results) != 100 {
		t.Errorf("Expected 100 results, got %d", len(results))
	}
}
```
No other tests were changed and all tests passed.
